### PR TITLE
Make line_agg_collec work with document transform and latest vispy ModularProgram

### DIFF
--- a/cr_paths/line_agg_collec.py
+++ b/cr_paths/line_agg_collec.py
@@ -224,7 +224,8 @@ if __name__ == '__main__':
     
     
     x = np.linspace(-1., 1., 1000)
-    y = .25*np.sin(15*x)
+    y = .25*np.sin(15*x) + 1.
+    print y
     vertices1 = np.c_[x,y]
     vertices2 = np.c_[np.cos(3*x)*.5, np.sin(3*x)*.5]
 

--- a/cr_paths/path2.vert
+++ b/cr_paths/path2.vert
@@ -23,17 +23,10 @@ vec4 transform(vec4);
 vec4 doc_px_transform(vec4);
 vec4 px_ndc_transform(vec4);
 
-vec2 transform_vector(vec2 x) {
-    vec4 o = transform(vec4(0, 0, 0, 1));
-    return (transform(vec4(x, 0, 1)) - o).xy;
+vec2 transform_vector(vec2 x, vec2 base) {
+    vec4 o = transform(vec4(base, 0, 1));
+    return (transform(vec4(base+x, 0, 1)) - o).xy;
 }
-
-vec2 doc_px_transform_vector(vec2 x) {
-    vec4 o = doc_px_transform(vec4(0, 0, 0, 1));
-    return (doc_px_transform(vec4(x, 0, 1)) - o).xy;
-}
-
-
 
 
 
@@ -131,8 +124,8 @@ void main()
     
     //vec2 t1 = normalize(tr_scale*a_tangents.xy);
     //vec2 t2 = normalize(tr_scale*a_tangents.zw);
-    vec2 t1 = normalize(transform_vector(a_tangents.xy));
-    vec2 t2 = normalize(transform_vector(a_tangents.zw));
+    vec2 t1 = normalize(transform_vector(a_tangents.xy, a_position));
+    vec2 t2 = normalize(transform_vector(a_tangents.zw, a_position));
     float u = a_texcoord.x;
     float v = a_texcoord.y;
     vec2 o1 = vec2( +t1.y, -t1.x);

--- a/cr_paths/plot.py
+++ b/cr_paths/plot.py
@@ -7,7 +7,7 @@ from vispy import app
 from vispy import gloo
 from vispy.scene.shaders import Function, ModularProgram
 from vispy.scene.visuals import Visual
-from vispy.scene.transforms import STTransform, NullTransform, AffineTransform
+from vispy.scene.transforms import STTransform, LogTransform, PolarTransform
 
 
 class PanZoomTransform(STTransform):
@@ -175,7 +175,7 @@ class PlotCanvas(app.Canvas):
     def add_visual(self, name, value):
         self._visuals.append(value)
         value._parent = self
-        value._program['transform'] = self.panzoom.shader_map()
+        value._program['transform'] = (self.panzoom * PolarTransform()).shader_map()
         value._program['doc_px_transform'] = self.doc_px_transform.shader_map()
         value._program['px_ndc_transform'] = self.px_ndc_transform.shader_map()
         


### PR DESCRIPTION
@Cyrille:  This modifies your agg line visual to use a document transform. To demonstrate the flexibility of this, I tossed in a polar transform. 

The transforms look like this:
- `transform` maps from the data coordinates to the _document_ coordinates, which I have defined as canvas pixels with 0,0 in the upper left. This transform is defined entirely using the panzoom, but this is not strictly necessary. The document coordinate system is where line widths are defined, and thus where they must be applied. 
- `doc_px_transform` would describe the difference between logical and physical pixels, but for us there will be no difference so it is an empty transform for now. We'll eventually need to test this on a high-res display..
- `px_ndc_transform` maps the rest of the way to NDC, and thus appears at the very end of the vertex shader. Both `doc_px` and `px_ndc` are defined by your Canvas subclass; eventually these should appear in the base Canvas class instead.
  
  There are probably still a few issues--I have not tested dashing, for example. I think for dashing to work correctly, it will be necessary to do the initial mapping to document coords on the CPU (because we can't measure distance along the path on the GPU).
